### PR TITLE
Docker API connection via TCP rather than unix socket

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,45 @@ PHP Docker client
 ==================
 > Docker API driver for PHP.
 
+Docker configuration
+--------------------
+Docker Engine API must be exposed on a local port in order to be able to connect.
+
+##### 1. Edit the `docker.service` which by default on debian is located at `/lib/systemd/system/docker.service`  
+
+From this:
+```shell
+# /lib/systemd/system/docker.service
+...
+ExecStart=/usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock
+...
+```
+
+To this:
+```shell
+# /lib/systemd/system/docker.service
+...
+ExecStart=/usr/bin/dockerd
+...
+```
+
+##### 2. Edit `/etc/docker/daemon.json` to expose docker api at `127.0.0.1:2375`
+Add `hosts` to the json file as next:
+```json
+{
+  ...
+  "hosts": ["fd://", "tcp://127.0.0.1:2375"]
+  ...
+}
+```
+
+##### 3. Restart Docker completely
+```shell
+systemctl daemon-reload
+systemctl restart docker
+service docker restart
+```
+
 Installation
 ------------
     composer require ibra-akv/php-docker-client
@@ -15,8 +54,7 @@ Initialize client
 use IterativeCode\Component\DockerClient\DockerClient;
 
 $docker = new DockerClient([
-    'docker_base_uri' => 'http://localhost/v1.41', # Optional (default: http://localhost/v1.41)
-    'unix_socket' => '/var/run/docker.sock' # Optional (defaukt: /var/run/docker.sock)
+    'local_endpoint' => 'http://localhost:2375/v1.41', # Optional (default: http://localhost:2375)
 ]);
 
 ```

--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,8 @@
 {
     "name": "ibra-akv/php-docker-client",
-    "version": "1.41.12",
-    "description": "Docker APIs driver for PHP.",
-    "homepage": "https://github.com/ibra-akv/php-docker-client",
+    "description": "Docker API driver for PHP.",
     "type": "library",
+    "homepage": "https://github.com/ibra-akv/php-docker-client",
     "license": "MIT",
     "authors": [
         {

--- a/docs/DockerClient.md
+++ b/docs/DockerClient.md
@@ -28,7 +28,7 @@ public __construct($options = [])
 $options : array
 ###### Tags
 **throws**
-- DockerSocketNotFound
+- DockerConnectionFailed
 
 
 #### listContainers()

--- a/src/Exception/DockerConnectionFailed.php
+++ b/src/Exception/DockerConnectionFailed.php
@@ -2,7 +2,7 @@
 
 namespace IterativeCode\Component\DockerClient\Exception;
 
-class DockerSocketNotFound extends \Exception
+class DockerConnectionFailed extends \Exception
 {
 
 }


### PR DESCRIPTION
Connecting to Docker API via TCP rather than unix socket for security purposes.

This change requires additional actions in the docker configuration to expose the api on a specific local port.