### PR TITLE
Switching from GuzzleHttp to Symfony's HttpClient

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,9 @@
         }
     },
     "require": {
+        "php": ">=7.1.3",
         "ext-curl": "*",
         "ext-json": "*",
-        "guzzlehttp/guzzle": ">=6.5.0"
+        "symfony/http-client": ">=4.4"
     }
 }


### PR DESCRIPTION
GuzzleHttp -> Symfony/HttpClient

Minimal PHP version: 7.1.3

Tested PHP versions:
 - 7.1
 - 7.2
 - 7.3
 - 7.4
 - 8.0
 - 8.1